### PR TITLE
Remove ruby rules from Nginx site conf

### DIFF
--- a/build/nginx/sites-enabled/default.conf
+++ b/build/nginx/sites-enabled/default.conf
@@ -47,15 +47,6 @@ server {
     deny all;
   }
 
-  # bundler
-  location ~* Gemfile(\.lock)?$ {
-    deny all;
-  }
-
-  location ~* gems\.(rb|locked)?$ {
-    deny all;
-  }
-
   location / {
     try_files $uri $uri/ /index.php?$args;
   }


### PR DESCRIPTION
I think this is a relic from super old capistrano days but we shouldn't care anymore. I'll remove these from Trellis too.